### PR TITLE
no more laravelcollective html forms, fastly update and delete

### DIFF
--- a/app/Providers/FastlyProvider.php
+++ b/app/Providers/FastlyProvider.php
@@ -62,6 +62,10 @@ class FastlyProvider extends ServiceProvider
                 $response));
 
         });
+
+        //deleted
+
+        //updated
     }
 
     /**

--- a/app/Providers/FastlyProvider.php
+++ b/app/Providers/FastlyProvider.php
@@ -64,8 +64,87 @@ class FastlyProvider extends ServiceProvider
         });
 
         //deleted
+         Redirect::deleted(function($redirect) {
+            Log::info(sprintf('Deleting Fastly redirect: %s => %s (%d)',
+                $redirect->path, $redirect->target, $redirect->http_status));
+
+
+            // Here's the hacky part....
+            $fastly_key = '30342701a122f58e935c9fe1024b8bc8';
+            $fastly_table_redirects = 'isbuug15ZlBduv6XWk0VU';
+            $fastly_table_redirect_types = '5v35JNHgaK2qFG5fNacSPO';
+
+            // Step one: Remove from 'redirects' table.
+            $ch = curl_init();
+            curl_setopt_array($ch, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_CUSTOMREQUEST => "DELETE",
+                CURLOPT_HTTPHEADER => array(sprintf('Fastly-Key: %s', $fastly_key)),
+                CURLOPT_URL => 'https://api.fastly.com/service/3uoN6UPm3Byl5RAkYuhTTk/dictionary/' . $fastly_table_redirects . '/item/' . $redirect->path,
+            ));
+            $response = curl_exec($ch);
+
+            Log::info(sprintf('Response: call 1: %s',
+                $response));
+
+            // Step two: Remove from 'redirect_types' table.
+            $ch = curl_init();
+            curl_setopt_array($ch, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_CUSTOMREQUEST => "DELETE",
+                CURLOPT_HTTPHEADER => array(sprintf('Fastly-Key: %s', $fastly_key)),
+                CURLOPT_URL => 'https://api.fastly.com/service/3uoN6UPm3Byl5RAkYuhTTk/dictionary/' . $fastly_table_redirect_types . '/item/' . $redirect->path,
+            ));
+            $response = curl_exec($ch);
+
+            Log::info(sprintf('Response: call 2: %s',
+                $response));
+
+        });
 
         //updated
+         Redirect::updated(function($redirect) {
+            Log::info(sprintf('Updating existing Fastly redirect: %s => %s (%d)',
+                $redirect->path, $redirect->target, $redirect->http_status));
+
+            // Here's the hacky part....
+            $fastly_key = '30342701a122f58e935c9fe1024b8bc8';
+            $fastly_table_redirects = 'isbuug15ZlBduv6XWk0VU';
+            $fastly_table_redirect_types = '5v35JNHgaK2qFG5fNacSPO';
+
+            // Step one: Update 'redirects' table.
+            $ch = curl_init();
+            curl_setopt_array($ch, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_CUSTOMREQUEST => "PUT",
+                CURLOPT_HTTPHEADER => array(sprintf('Fastly-Key: %s', $fastly_key)),
+                CURLOPT_URL => 'https://api.fastly.com/service/3uoN6UPm3Byl5RAkYuhTTk/dictionary/' . $fastly_table_redirects . '/item/' . $redirect->path,
+                CURLOPT_POSTFIELDS => array(
+                    'item_value' => $redirect->target,
+                ),
+            ));
+            $response = curl_exec($ch);
+
+            Log::info(sprintf('Response: call 1: %s',
+                $response));
+
+            // Step two: Update 'redirect_types' table.
+            $ch = curl_init();
+            curl_setopt_array($ch, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_CUSTOMREQUEST => "PUT",
+                CURLOPT_HTTPHEADER => array(sprintf('Fastly-Key: %s', $fastly_key)),
+                CURLOPT_URL => 'https://api.fastly.com/service/3uoN6UPm3Byl5RAkYuhTTk/dictionary/' . $fastly_table_redirect_types . '/item/' . $redirect->path,
+                CURLOPT_POSTFIELDS => array(
+                    'item_value' => $redirect->http_status,
+                ),
+            ));
+            $response = curl_exec($ch);
+
+            Log::info(sprintf('Response: call 2: %s',
+                $response));
+
+        });
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "5.2.*",
-        "guzzlehttp/guzzle": "^6.1",
-        "laravelcollective/html": "^5.2"
+        "guzzlehttp/guzzle": "^6.1"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5ff53855262d63b8b99a002527af038c",
-    "content-hash": "ffc6d8f8edfc82716d5d3226deb94a2a",
+    "hash": "17dcb848077f0e7190344ded5decc244",
+    "content-hash": "27a36a3d0dc31812f5f508e57b8d01fd",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -479,16 +479,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.2.25",
+            "version": "v5.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "d2817d2773dc3f405b561762489a76bbe66bd673"
+                "reference": "b73ac62506c5c2bd49d87fcb1089f7759431e173"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d2817d2773dc3f405b561762489a76bbe66bd673",
-                "reference": "d2817d2773dc3f405b561762489a76bbe66bd673",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/b73ac62506c5c2bd49d87fcb1089f7759431e173",
+                "reference": "b73ac62506c5c2bd49d87fcb1089f7759431e173",
                 "shasum": ""
             },
             "require": {
@@ -603,61 +603,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-03-24 15:06:38"
-        },
-        {
-            "name": "laravelcollective/html",
-            "version": "v5.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/LaravelCollective/html.git",
-                "reference": "3a312d39ffe37da0f57b602618b61fd07c1fcec5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/3a312d39ffe37da0f57b602618b61fd07c1fcec5",
-                "reference": "3a312d39ffe37da0f57b602618b61fd07c1fcec5",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/http": "5.2.*",
-                "illuminate/routing": "5.2.*",
-                "illuminate/session": "5.2.*",
-                "illuminate/support": "5.2.*",
-                "illuminate/view": "5.2.*",
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "illuminate/database": "5.2.*",
-                "mockery/mockery": "~0.9",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Collective\\Html\\": "src/"
-                },
-                "files": [
-                    "src/helpers.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylorotwell@gmail.com"
-                },
-                {
-                    "name": "Adam Engebretson",
-                    "email": "adam@laravelcollective.com"
-                }
-            ],
-            "description": "HTML and Form Builders for the Laravel Framework",
-            "homepage": "http://laravelcollective.com",
-            "time": "2016-01-27 22:29:54"
+            "time": "2016-03-25 17:12:52"
         },
         {
             "name": "league/flysystem",

--- a/config/app.php
+++ b/config/app.php
@@ -158,7 +158,6 @@ return [
 
         Nightwing\Providers\FastlyProvider::class,
 
-        Collective\Html\HtmlServiceProvider::class,
 
     ],
 
@@ -209,8 +208,7 @@ return [
         /*
          * Third-Party Aliases...
          */
-        'Form' => Collective\Html\FormFacade::class,
-        'Html' => Collective\Html\HtmlFacade::class,
+
     ],
 
 ];

--- a/resources/views/redirects/create.blade.php
+++ b/resources/views/redirects/create.blade.php
@@ -13,14 +13,17 @@
 
                 <form action="{{ url('redirects') }}" method="POST" class="form-horizontal">
                     {!! csrf_field() !!}
+
                     <div class="form-item -padded">
                         <label for="path" class="field-label">Path</label>
                         <input type="text" name="path" id="task-path" class="text-field">
                     </div>
+
                     <div class="form-item -padded">
                         <label for="target" class="field-label">Target URL</label>
                         <input type="text" name="target" id="task-target" class="text-field">
                     </div>
+
                     <div class="form-item -padded">
                         <label for="http_status" class="field-label">Response type</label>
                         <select name="http_status" id="task-http_status">
@@ -28,11 +31,13 @@
                             <option value="302">302 Temporary</option>
                         </select>
                     </div>
+
                     <div class="form-actions">
                         <button type="submit" class="button" name="complete">
                             Add redirect
                         </button>
                     </div>
+
                 </form>
             </div>
         </div>

--- a/resources/views/redirects/edit.blade.php
+++ b/resources/views/redirects/edit.blade.php
@@ -10,28 +10,35 @@
 </div>
 <div class='container__block'>
     <div class='wrapper'>
-        {!! Form::model($redirect, ['method' => 'PATCH', 'route' => ['redirects.update', $redirect->id]]) !!}
+        <form method="POST" action="{{ route('redirects.update', $redirect->id) }}">
+            {{ method_field('PATCH') }}
 
-            <div class="form-item">
-                {!! Form::label('path', 'Path: ', array('class' => 'field-label')) !!}
-                {!! Form::text('path', NULL, array('class' => 'text-field')) !!}
-            </div>
+            {{ csrf_field() }}
 
-            <div class="form-item">
-                {!! Form::label('target', 'Target: ', array('class' => 'field-label')) !!}
-                {!! Form::text('target', NULL, array('class' => 'text-field')) !!}
+            <div class="form-item -padded">
+                <label for="path" class="field-label">Path:</label>
+                <input name="path" type="text" class="text-field" value="{{ $redirect->path }}"/>
             </div>
 
             <div class="form-item -padded">
-                {!! Form::label('http_status', 'Response type:', ['class' => 'field-label'])!!}
-                {!! Form::select('http_status', ['301' => '301 Permanent', '302' => '302 Temporary']) !!}
+                <label class="field-label">Target:</label>
+                <input name="target" type="text" class="text-field" value="{{ $redirect->target }}"/>
             </div>
 
-            <div class="form-item">
-                {!! Form::submit('Update Redirect',  ['class' => 'button']) !!}
+            <div class="form-item -padded">
+                <label for="http_status" class="field-label">Response type:</label>
+                <select name="http_status">
+                    <option value="301" {{ $redirect->http_status == '301' ? 'selected' : '' }}>301 Permanent</option>
+                    <option value="302" {{ $redirect->http_status == '302' ? 'selected' : '' }}>302 Temporary</option>
+                </select>
             </div>
 
-        {!! Form::close() !!}
+             <div class="form-item">
+                <button type="submit" class="button">
+                    Update redirect
+                </button>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/resources/views/redirects/edit.blade.php
+++ b/resources/views/redirects/edit.blade.php
@@ -17,7 +17,7 @@
 
             <div class="form-item -padded">
                 <label for="path" class="field-label">Path:</label>
-                <input name="path" type="text" class="text-field" value="{{ $redirect->path }}"/>
+                <input name="path" type="text" class="text-field" value="{{ $redirect->path }}" disabled/>
             </div>
 
             <div class="form-item -padded">

--- a/resources/views/redirects/show.blade.php
+++ b/resources/views/redirects/show.blade.php
@@ -24,11 +24,14 @@
 					<li>
 						<a href="{{ route('redirects.edit', $redirect->id) }}" class="button">Edit redirect</a>
 					</li>
-					<li>
-						{!! Form::open(['method' => 'DELETE','route' => ['redirects.destroy', $redirect->id]]) !!}
-						{!! Form::submit('Delete', array('class' => 'button delete')) !!}
-						{!! Form::close() !!}
-					</li>
+					<li>				
+                        <form method="POST" action="{{ route('redirects.destroy', $redirect->id) }}">
+                            {{ method_field('DELETE') }}
+                            {{ csrf_field() }}
+
+                            <input type="submit" class="button -danger" value="Delete" />
+                        </form>
+                    </li>
 				</ul>
 
             </div>


### PR DESCRIPTION
- changed all the forms to not rely on the laravelcollective/html stuff
- updated `FastlyProvider.php` to update and delete fastly tables when redirects are edited or deleted
- no longer allow users to edit paths, they must delete the current redirect and create a new one if they wish to alter the path
##### Issues:

Fixes #1 
and most of #2 (still need to add delete confirmation)

cc: @weerd 
